### PR TITLE
Limit output of validator

### DIFF
--- a/estep/validate.py
+++ b/estep/validate.py
@@ -101,17 +101,20 @@ class Validator(object):
         if has_errors:
             LOGGER.info('Document: %s OK', name)
         else:
-            LOGGER.warning('Document: %s BAD (schema:%s)\n-------------------------------------------------\n', name, schema_uri)
+            warning_msg = 'Document: {0} BAD (schema: {1})'.format(name, schema_uri)
+            separator = '-'*len(warning_msg)
+            LOGGER.warning(separator)
+            LOGGER.warning(warning_msg)
+            LOGGER.warning(separator + '\n')
             for error in errors:
-                LOGGER.warning('Error > ')
-                LOGGER.warning('  Message    : ' + error.message)
+                LOGGER.warning('* Error      : ' + error.message)
                 if error.cause is not None:
                     LOGGER.warning('  Cause      : ' + str(error.cause))
-                LOGGER.warning('  On property: ' + '.'.join(error.relative_schema_path))
+                LOGGER.warning('  On property: ' + '.'.join(list(error.relative_schema_path)[1:]))
                 if len(error.context) > 0:
-                    LOGGER.warning('  Underlying :')
+                    LOGGER.warning('  Reasons    :')
                     for c in error.context:
-                        LOGGER.warning('  - Message: ' + c.message)
+                        LOGGER.warning('  - Error: ' + c.message)
                         if c.cause is not None:
-                            LOGGER.warning('    Cause  : ' + str(c.cause))
+                            LOGGER.warning('    Cause: ' + str(c.cause))
         return len(errors)

--- a/estep/validate.py
+++ b/estep/validate.py
@@ -93,6 +93,8 @@ class Validator(object):
         else:
             LOGGER.warning('Document: %s BAD (schema:%s)\n-------------------------------------------------\n', name, schema_uri)
             for error in errors:
-                LOGGER.warning(' > ' + error.message)
+                LOGGER.warning('Error > ')
+                LOGGER.warning('  Message    : ' + error.message)
+                LOGGER.warning('  On property: ' + '.'.join(error.relative_schema_path))
             LOGGER.warning('-------------------------------------------------')
         return len(errors)

--- a/estep/validate.py
+++ b/estep/validate.py
@@ -93,6 +93,6 @@ class Validator(object):
         else:
             LOGGER.warning('Document: %s BAD (schema:%s)\n-------------------------------------------------\n', name, schema_uri)
             for error in errors:
-                LOGGER.warning(error)
+                LOGGER.warning(' > ' + error.message)
             LOGGER.warning('-------------------------------------------------')
         return len(errors)


### PR DESCRIPTION
Perhaps it is more useful to print only a [human readable message explaining the error.](https://python-jsonschema.readthedocs.org/en/latest/errors/) instead of the error itself, which outputs the complete schema each time and makes it a bit harder to read ?