### PR TITLE
Condense properties using columns, fill up less space

### DIFF
--- a/_layouts/organization.html
+++ b/_layouts/organization.html
@@ -15,70 +15,84 @@ layout: default
 
 <hr/>
 
+<div class="properties">
+
 {% if page.nlescWebsite != null || page.website != null || page.twitterUrl != null || page.linkedInUrl != null || page.githubUrl != null || page.researchgateUrl != null %}
+<div class="property">
 <h3>Links</h3>
 <ul class="link-list">
 {% unless page.website == null %}
-<li><a href="{{ d.website }}">website</a></li>
+<li><a href="{{ page.website }}">website</a></li>
 {% endunless %}
 {% unless page.nlescWebsite == null %}
-<li><a href="{{ d.nlescWebsite }}">NLeSC website</a></li>
+<li><a href="{{ page.nlescWebsite }}">NLeSC website</a></li>
 {% endunless %}
 {% unless page.researchgateUrl == null %}
-<li><a href="{{ d.researchgateUrl }}">ResearchGate</a></li>
+<li><a href="{{ page.researchgateUrl }}">ResearchGate</a></li>
 {% endunless %}
 {% unless page.githubUrl == null %}
-<li><a href="{{ d.githubUrl }}">GitHub</a></li>
+<li><a href="{{ page.githubUrl }}">GitHub</a></li>
 {% endunless %}
 {% unless page.twitterUrl == null %}
-<li><a href="{{ d.twitterUrl }}">Twitter</a></li>
+<li><a href="{{ page.twitterUrl }}">Twitter</a></li>
 {% endunless %}
 {% unless page.linkedInUrl == null %}
-<li><a href="{{ d.linkedInUrl }}">LinkedIn</a></li>
+<li><a href="{{ page.linkedInUrl }}">LinkedIn</a></li>
 {% endunless %}
 </ul>
+</div>
 {% endif %}
 
 {% capture d %}{{ page.involvedIn }}{% endcapture %}
 {% if d != empty %}
+<div class="property">
   <h3>Involved in</h3>
   <ul class="involved-in-list">
   {% for d in page.involvedIn %}
   <li>{% if d contains site.url %}<a href="{{ d }}">{% capture pname %}{{ d }}{% endcapture %}{% for p in site.project %}{% capture urlx %}{{ p.url | replace:'.html','' | prepend: site.url }}{% endcapture %}{% if urlx contains d %}{% capture pname %}{{ p.name }}{% endcapture %}{% endif %}{% endfor %}{{ pname }}</a>{% elsif d.name %}{% if d.link %}<a href="{{ d.link[0].url }}">{% endif %}{{ d.name }}{% if d.link %}</a>{% endif %}{% else %}{{ d }}{% endif %}</li>
   {% endfor %}
   </ul>
+</div>
 {% endif %}
 
 {% capture d %}{{ page.organizationOf }}{% endcapture %}
 {% if d != empty %}
+<div class="property">
   <h3>Organization of</h3>
   <ul class="organization-of-list">
   {% for d in page.organizationOf %}
   <li>{% if d contains site.url %}<a href="{{ d }}">{% capture pname %}{{ d }}{% endcapture %}{% for p in site.person %}{% capture urlx %}{{ p.url | replace:'.html','' | prepend: site.url }}{% endcapture %}{% if urlx contains d %}{% capture pname %}{{ p.name }}{% endcapture %}{% endif %}{% endfor %}{{ pname }}</a>{% elsif d.name %}{% if d.link %}<a href="{{ d.link[0].url }}">{% endif %}{{ d.name }}{% if d.link %}</a>{% endif %}{% else %}{{ d }}{% endif %}</li>
   {% endfor %}
   </ul>
+</div>
 {% endif %}
 
 {% capture d %}{{ page.ownerOf }}{% endcapture %}
 {% if d != empty %}
+<div class="property">
   <h3>Owner of</h3>
   <ul class="owner-of-list">
   {% for d in page.ownerOf %}
   <li>{% if d contains site.url %}<a href="{{ d }}">{% capture pname %}{{ d }}{% endcapture %}{% for p in site.software %}{% capture urlx %}{{ p.url | replace:'.html','' | prepend: site.url }}{% endcapture %}{% if urlx contains d %}{% capture pname %}{{ p.name }}{% endcapture %}{% endif %}{% endfor %}{{ pname }}</a>{% elsif d.name %}{% if d.link %}<a href="{{ d.link[0].url }}">{% endif %}{{ d.name }}{% if d.link %}</a>{% endif %}{% else %}{{ d }}{% endif %}</li>
   {% endfor %}
   </ul>
+</div>
 {% endif %}
 
 
 {% capture d %}{{ page.userOf }}{% endcapture %}
 {% if d != empty %}
+<div class="property">
   <h3>User of</h3>
   <ul class="user-of-list">
   {% for d in page.userOf %}
   <li>{% if d contains site.url %}<a href="{{ d }}">{% capture pname %}{{ d }}{% endcapture %}{% for p in site.software %}{% capture urlx %}{{ p.url | replace:'.html','' | prepend: site.url }}{% endcapture %}{% if urlx contains d %}{% capture pname %}{{ p.name }}{% endcapture %}{% endif %}{% endfor %}{{ pname }}</a>{% elsif d.name %}{% if d.link %}<a href="{{ d.link[0].url }}">{% endif %}{{ d.name }}{% if d.link %}</a>{% endif %}{% else %}{{ d }}{% endif %}</li>
   {% endfor %}
   </ul>
+</div>
 {% endif %}
+
+</div>
 
 <hr/>
 

--- a/_layouts/person.html
+++ b/_layouts/person.html
@@ -14,8 +14,9 @@ layout: default
 
 <hr/>
 
-
+<div class="properties">
 {% if page.nlescWebsite != null || page.website != null || page.twitterUrl != null || page.linkedInUrl != null || page.githubUrl != null || page.researchgateUrl != null %}
+<div class="property">
 <h3>Links</h3>
 <ul class="link-list">
 {% unless page.website == null %}
@@ -37,32 +38,38 @@ layout: default
 <li><a href="{{ page.linkedInUrl }}">LinkedIn</a></li>
 {% endunless %}
 </ul>
+</div>
 {% endif %}
 
 
 {% capture d %}{{ page.contactPersonOf }}{% endcapture %}
 {% if d != empty %}
+<div class="property">
 	<h3>Contact person of</h3>
 	<ul class="contact-person-of-list">
 	{% for d in page.contactPersonOf %}
 		<li>{% capture pname %}{% endcapture %}{% if d.name == null %}<a href="{{ d }}">{% for p in site.person %}{% capture urlx %}{{ p.url | replace:'.html','' | prepend: site.url }}{% endcapture %}{% if urlx contains d %}{% capture pname %}{{ p.name }}{% endcapture %}{% endif %}{% endfor %}{% if pname == "" %}{{ d }}{% else %}{{ pname }}{% endif %}</a>{% elsif d.name %}{% if d.githubUrl %}<a href="{{ d.githubUrl }}">{{ d.name }}</a>{% elsif d.linkedInUrl %}<a href="{{ d.linkedInUrl }}">{{ d.name }}</a>{% elsif d.twitterUrl %}<a href="{{ d.twitterUrl }}">{{ d.name }}</a>{% elsif d.website %}<a href="{{ d.website }}">{{ d.name }}</a>{% else %}{{ d.name }}{% endif %}{% else %}{{ d }}{% endif %}</li>
 {% endfor %}
 	</ul>
+</div>
 {% endif %}
 
 {% capture d %}{{ page.ownerOf }}{% endcapture %}
 {% if d != empty %}
+<div class="property">
 	<h3>Owner of</h3>
 	<ul class="owner-of-list">
 	{% for d in page.ownerOf %}
 		<li>{% capture pname %}{% endcapture %}{% if d.name == null %}<a href="{{ d }}">{% for p in site.software %}{% capture urlx %}{{ p.url | replace:'.html','' | prepend: site.url }}{% endcapture %}{% if urlx contains d %}{% capture pname %}{{ p.name }}{% endcapture %}{% endif %}{% endfor %}{% if pname == "" %}{{ d }}{% else %}{{ pname }}{% endif %}</a>{% elsif d.name %}{% if d.githubUrl %}<a href="{{ d.githubUrl }}">{{ d.name }}</a>{% elsif d.linkedInUrl %}<a href="{{ d.linkedInUrl }}">{{ d.name }}</a>{% elsif d.twitterUrl %}<a href="{{ d.twitterUrl }}">{{ d.name }}</a>{% elsif d.website %}<a href="{{ d.website }}">{{ d.name }}</a>{% else %}{{ d.name }}{% endif %}{% else %}{{ d }}{% endif %}</li>
 	{% endfor %}
 	</ul>
+</div>
 {% endif %}
 
 
 {% capture d %}{{ page.engineerOf }}{% endcapture %}
 {% if d != empty %}
+<div class="property">
 	<h3>eScience Engineer in</h3>
 	<ul class="engineer-of-list">
 	{% for d in page.engineerOf %}
@@ -83,10 +90,12 @@ layout: default
 	</li>
 	{% endfor %}
 	</ul>
+</div>
 {% endif %}
 
 {% capture d %}{{ page.contributorOf }}{% endcapture %}
 {% if d != empty %}
+<div class="property">
 	<h3>Contributes to</h3>
 	<ul class="contributor-of-list">
 	{% for d in page.contributorOf %}
@@ -107,10 +116,12 @@ layout: default
 	</li>
 	{% endfor %}
 	</ul>
+</div>
 {% endif %}
 
 {% capture d %}{{ page.userOf }}{% endcapture %}
 {% if d != empty %}
+<div class="property">
 	<h3>User of</h3>
 	<ul class="user-of-list">
 	{% for d in page.userOf %}
@@ -131,7 +142,9 @@ layout: default
 	</li>
 	{% endfor %}
 	</ul>
+</div>
 {% endif %}
+</div>
 
 <hr/>
 

--- a/_layouts/project.html
+++ b/_layouts/project.html
@@ -12,7 +12,9 @@ layout: default
 {% endunless %}
 
 
+<div class="properties">
 {% if page.nlescWebsite != null || page.website != null %}
+<div class="property">
 <h3>Links</h3>
 <ul class="link-list">
 {% unless page.website == null %}
@@ -22,59 +24,73 @@ layout: default
 <li><a href="{{ page.nlescWebsite }}">NLeSC website</a></li>
 {% endunless %}
 </ul>
+</div>
 {% endif %}
 
 {% if page.startDate != null %}
+<div class="property">
 <h3>Start Date</h3>
 <div class="start-date">
 {{ page.startDate }}
 </div>
+</div>
 {% endif %}
 
 {% if page.endDate != null %}
+<div class="property">
 <h3>End Date</h3>
 <div class="start-date">
 {{ page.endDate }}
 </div>
+</div>
 {% endif %}
 
-
+<div class="property">
 <h3>Discipline</h3>
 <ul class="discipline-list">
 {% for d in page.discipline %}
 <li><a href="/software#discipline={{ d | cgi_escape }}">{{ d }}</a></li>
 {% endfor %}
 </ul>
+</div>
 
+<div class="property">
 <h3>Competence</h3>
 <ul class="competence-list">
 {% for d in page.competence %}
 <li><a href="/software#competence={{ d | cgi_escape }}">{{ d }}</a></li>
 {% endfor %}
 </ul>
+</div>
 
+<div class="property">
 <h3>Expertise</h3>
 <ul class="expertise-list">
 {% for d in page.expertise %}
 <li><a href="/software#expertise={{ d | cgi_escape }}">{{ d }}</a></li>
 {% endfor %}
 </ul>
+</div>
 
+<div class="property">
 <h3>Data formats used</h3>
 <ul class="data-format-list">
 {% for d in page.dataFormat %}
 <li>{{ d }}</li>
 {% endfor %}
 </ul>
+</div>
 
+<div class="property">
 <h3>Data magnitude</h3>
 <ul class="data-magnitude-list">
 {% for d in page.dataMagnitude %}
 <li>{{ d }}</li>
 {% endfor %}
 </ul>
+</div>
 
-
+<div class="property">
 <h3>Contact person</h3>
 {% capture d %}{{ page.contactPerson }}{% endcapture %}
 {% capture pname %}{% endcapture %}
@@ -104,7 +120,9 @@ layout: default
 {% else %}
 	{{ d }}
 {% endif %}
+</div>
 
+<div class="property">
 {% if page.principalInvestigator != null %}
 <h3>Principal investigator</h3>
 <ul class="principal-investigator-list">
@@ -113,33 +131,41 @@ layout: default
 {% endfor %}
 </ul>
 {% endif %}
+</div>
 
 {% if page.coordinator != null %}
+<div class="property">
 <h3>Project coordinator</h3>
 <ul class="coordinator-list">
 {% for d in page.coordinator %}
 	<li>{% capture pname %}{% endcapture %}{% if d.name == null %}<a href="{{ d }}">{% for p in site.person %}{% capture urlx %}{{ p.url | replace:'.html','' | prepend: site.url }}{% endcapture %}{% if urlx contains d %}{% capture pname %}{{ p.name }}{% endcapture %}{% endif %}{% endfor %}{% if pname == "" %}{{ d }}{% else %}{{ pname }}{% endif %}</a>{% elsif d.name %}{% if d.githubUrl %}<a href="{{ d.githubUrl }}">{{ d.name }}</a>{% elsif d.linkedInUrl %}<a href="{{ d.linkedInUrl }}">{{ d.name }}</a>{% elsif d.twitterUrl %}<a href="{{ d.twitterUrl }}">{{ d.name }}</a>{% elsif d.website %}<a href="{{ d.website }}">{{ d.name }}</a>{% else %}{{ d.name }}{% endif %}{% else %}{{ d }}{% endif %}</li>
 {% endfor %}
 </ul>
+</div>
 {% endif %}
 
 {% if page.involvedOrganizations != null %}
+<div class="property">
 <h3>Involved organizations</h3>
 <ul class="involved-organization-list">
 {% for d in page.involvedOrganization %}
 	<li>{% capture pname %}{% endcapture %}{% if d contains site.url %}<a href="{{ d }}">{% capture pname %}{{ d }}{% endcapture %}{% for p in site.organization %}{% capture urlx %}{{ p.url | replace:'.html','' | prepend: site.url }}{% endcapture %}{% if urlx contains d %}{% capture pname %}{{ p.name }}{% endcapture %}{% endif %}{% endfor %}{% if pname == "" %}{{ d }}{% else %}{{ pname }}{% endif %}</a>{% elsif d.name %}{% if d.link %}<a href="{{ d.website }}">{% endif %}{{ d.name }}{% if d.link %}</a>{% endif %}{% else %}{{ d }}{% endif %}</li>
 {% endfor %}
 </ul>
+</div>
 {% endif %}
 
 {% if page.uses != null %}
+<div class="property">
 <h3>Uses software</h3>
 <ul class="uses-list">
 {% for d in page.uses %}
 	<li>{% capture pname %}{% endcapture %}{% if d contains site.url %}<a href="{{ d }}">{% capture pname %}{{ d }}{% endcapture %}{% for p in site.software %}{% capture urlx %}{{ p.url | replace:'.html','' | prepend: site.url }}{% endcapture %}{% if urlx contains d %}{% capture pname %}{{ p.name }}{% endcapture %}{% endif %}{% endfor %}{% if pname == "" %}{{ d }}{% else %}{{ pname }}{% endif %}</a>{% elsif d.name %}{% if d.link %}<a href="{{ d.website }}">{% endif %}{{ d.name }}{% if d.link %}</a>{% endif %}{% else %}{{ d }}{% endif %}</li>
 {% endfor %}
 </ul>
+</div>
 {% endif %}
+</div>
 
 <hr/>
 

--- a/_layouts/software.html
+++ b/_layouts/software.html
@@ -9,7 +9,9 @@ layout: default
 <img src="{{ page.logo }}" class="logo"/>
 {% endunless %}
 
+<div class="properties">
 {% if page.codeRepository != null || page.nlescWebsite != null || page.website != null || page.documentationUrl != null || page.downloadUrl != null || page.doi != null %}
+<div class="property">
 <h3>Links</h3>
 <ul class="link-list">
 {% unless page.website == null %}
@@ -31,78 +33,100 @@ layout: default
 <li><a href="{{ page.doi }}">DOI</a></li>
 {% endunless %}
 </ul>
+</div>
 {% endif %}
 
+<div class="property">
 <h3>Start Date</h3>
 <div class="start-date">
 {{ page.startDate }}
 </div>
+</div>
 
+<div class="property">
 <h3>Status</h3>
 <div class="status">
 <a href="/software#status={{ page.status | cgi_escape }}">{{ page.status }}</a>
 </div>
+</div>
 
+<div class="property">
 <h3>Discipline</h3>
 <ul class="discipline-list">
 {% for d in page.discipline %}
 <li><a href="/software#discipline={{ d | cgi_escape }}">{{ d }}</a></li>
 {% endfor %}
 </ul>
+</div>
 
+<div class="property">
 <h3>Competence</h3>
 <ul class="competence-list">
 {% for d in page.competence %}
 <li><a href="/software#competence={{ d | cgi_escape }}">{{ d }}</a></li>
 {% endfor %}
 </ul>
+</div>
 
+<div class="property">
 <h3>Expertise</h3>
 <ul class="expertise-list">
 {% for d in page.expertise %}
 <li><a href="/software#expertise={{ d | cgi_escape }}">{{ d }}</a></li>
 {% endfor %}
 </ul>
+</div>
 
+<div class="property">
 <h3>Programming Language</h3>
 <ul class="programming-language-list">
 {% for d in page.programmingLanguage %}
 <li><a href="/software#programmingLanguage={{ d | cgi_escape }}">{{ d }}</a></li>
 {% endfor %}
 </ul>
+</div>
 
+<div class="property">
 <h3>License</h3>
 <ul class="license-list">
 {% for d in page.license %}
 <li>{{ d }}</li>
 {% endfor %}
 </ul>
+</div>
 
+<div class="property">
 <h3>Tags</h3>
 <ul class="technology-tag-list">
 {% for d in page.technologyTag %}
 <li><a href="/software#technologyTag={{ d | cgi_escape }}">{{ d }}</a></li>
 {% endfor %}
 </ul>
+</div>
 
 {% if page.dependency != null %}
+<div class="property">
 <h3>Dependencies</h3>
 <ul class="dependency-list">
 {% for d in page.dependency %}
 	<li>{% capture pname %}{% endcapture %}{% if d contains site.url %}<a href="{{ d }}">{% capture pname %}{{ d }}{% endcapture %}{% for p in site.software %}{% capture urlx %}{{ p.url | replace:'.html','' | prepend: site.url }}{% endcapture %}{% if urlx contains d %}{% capture pname %}{% if pname %}{{ p.name }}{% else %}{{ pname }}{% endif %}{% endcapture %}{% endif %}{% endfor %}{{ pname }}</a>{% elsif d.name %}{% if d.website != null %}<a href="{{ d.website }}">{% endif %}{{ d.name }}{% if d.website != null %}</a>{% endif %}{% else %}{{ d }}{% endif %}</li>
 	{% endfor %}
 </ul>
+</div>
 {% endif %}
 
 {% if page.dependencyOf != null %}
+<div class="property">
 <h3>Dependency of</h3>
 <ul class="dependency-of-list">
 {% for d in page.dependencyOf %}
 	<li>{% capture pname %}{% endcapture %}{% if d contains site.url %}<a href="{{ d }}">{% capture pname %}{{ d }}{% endcapture %}{% for p in site.software %}{% capture urlx %}{{ p.url | replace:'.html','' | prepend: site.url }}{% endcapture %}{% if urlx contains d %}{% capture pname %}{% if pname %}{{ p.name }}{% else %}{{ pname }}{% endif %}{% endcapture %}{% endif %}{% endfor %}{{ pname }}</a>{% elsif d.name %}{% if d.website != null %}<a href="{{ d.website }}">{% endif %}{{ d.name }}{% if d.website != null %}</a>{% endif %}{% else %}{{ d }}{% endif %}</li>
 	{% endfor %}
 </ul>
+</div>
 {% endif %}
 
+<div class="property">
 <h3>Contact Person</h3>
 {% capture d %}{{ page.contactPerson.name }}{% endcapture %}
 {% capture pname %}{% endcapture %}
@@ -133,7 +157,9 @@ layout: default
 {% else %}
 	{{ d }}
 {% endif %}
+</div>
 
+<div class="property">
 <h3>Owner</h3>
 {% capture d %}{{ page.owner.name }}{% endcapture %}
 {% capture pname %}{% endcapture %}
@@ -169,34 +195,42 @@ layout: default
 {% else %}
 	{{ d }}
 {% endif %}
+</div>
 
 {% if page.contributor != null %}
+<div class="property">
 <h3>Contributors</h3>
 <ul class="contributor-list">
 {% for d in page.contributor %}
 	<li>{% capture pname %}{% endcapture %}{% if d.name == null %}<a href="{{ d }}">{% for p in site.person %}{% capture urlx %}{{ p.url | replace:'.html','' | prepend: site.url }}{% endcapture %}{% if urlx contains d %}{% capture pname %}{{ p.name }}{% endcapture %}{% endif %}{% endfor %}{% if pname == "" %}{{ d }}{% else %}{{ pname }}{% endif %}</a>{% elsif d.name %}{% if d.githubUrl %}<a href="{{ d.githubUrl }}">{{ d.name }}</a>{% elsif d.linkedInUrl %}<a href="{{ d.linkedInUrl }}">{{ d.name }}</a>{% elsif d.twitterUrl %}<a href="{{ d.twitterUrl }}">{{ d.name }}</a>{% elsif d.website %}<a href="{{ d.website }}">{{ d.name }}</a>{% else %}{{ d.name }}{% endif %}{% else %}{{ d }}{% endif %}</li>
 {% endfor %}
 </ul>
+</div>
 {% endif %}
 
 {% if page.involvedOrganization != null %}
+<div class="property">
 <h3>Involved Organizations</h3>
 <ul class="involved-organization-list">
 {% for d in page.involvedOrganization %}
 	<li>{% capture pname %}{% endcapture %}{% if d contains site.url %}<a href="{{ d }}">{% capture pname %}{{ d }}{% endcapture %}{% for p in site.organization %}{% capture urlx %}{{ p.url | replace:'.html','' | prepend: site.url }}{% endcapture %}{% if urlx contains d %}{% capture pname %}{{ p.name }}{% endcapture %}{% endif %}{% endfor %}{% if pname == "" %}{{ d }}{% else %}{{ pname }}{% endif %}</a>{% elsif d.name %}{% if d.link %}<a href="{{ d.website }}">{% endif %}{{ d.name }}{% if d.link %}</a>{% endif %}{% else %}{{ d }}{% endif %}</li>
 {% endfor %}
 </ul>
+</div>
 {% endif %}
 
 {% if page.user != null %}
+<div class="property">
 <h3>Users</h3>
 <ul class="user-list">
 {% for d in page.user %}
 	<li>{% capture pname %}{% endcapture %}{% if d.name == null %}<a href="{{ d }}">{% for p in site.person %}{% capture urlx %}{{ p.url | replace:'.html','' | prepend: site.url }}{% endcapture %}{% if urlx contains d %}{% capture pname %}{{ p.name }}{% endcapture %}{% endif %}{% endfor %}{% for p in site.organization %}{% capture urlx %}{{ p.url | replace:'.html','' | prepend: site.url }}{% endcapture %}{% if urlx contains d %}{% capture pname %}{{ p.name }}{% endcapture %}{% endif %}{% endfor %}{% if pname == "" %}{{ d }}{% else %}{{ pname }}{% endif %}</a>{% elsif d.name %}{% if d.githubUrl %}<a href="{{ d.githubUrl }}">{{ d.name }}</a>{% elsif d.linkedInUrl %}<a href="{{ d.linkedInUrl }}">{{ d.name }}</a>{% elsif d.twitterUrl %}<a href="{{ d.twitterUrl }}">{{ d.name }}</a>{% elsif d.website %}<a href="{{ d.website }}">{{ d.name }}</a>{% else %}{{ d.name }}{% endif %}{% else %}{{ d }}{% endif %}</li>{% endfor %}
 </ul>
+</div>
 {% endif %}
 
 {% if page.usedIn != null %}
+<div class="property">
 <h3>Used in Projects</h3>
 <ul class="used-in-list">
 {% for d in page.usedIn %}
@@ -217,7 +251,10 @@ layout: default
 	</li>
 {% endfor %}
 </ul>
+</div>
 {% endif %}
+
+</div>
 
 <hr/>
 

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -252,6 +252,24 @@
     margin-bottom: 10px;
 }
 
+.properties {
+    -webkit-column-count: 3; /* Chrome, Safari, Opera */
+    -moz-column-count: 3; /* Firefox */
+    column-count: 3;
+}
+
+.property {
+  /* keep property in single column. */
+  overflow: hidden; /* fix for Firefox */
+  break-inside: avoid-column;
+  page-break-inside: avoid-column;
+  -webkit-column-break-inside: avoid;
+}
+
+.properties h3, .property h3 {
+  font-size: 1.1em;
+}
+
 /**
  * Software overview page
  */
@@ -323,7 +341,7 @@
     font-weight: bold;
 }
 
-.deselected {opacity:0} 
+.deselected {opacity:0}
 
 .chart-container {
     margin-right: 15px;


### PR DESCRIPTION
Website metadata takes a lot of space now. Updated to use columns and smaller headings.
Before:
![xenon_old](https://cloud.githubusercontent.com/assets/313450/14318510/6d07f23e-fc0d-11e5-8b01-fa49f47ca5b4.png)
After:
![xenon_new](https://cloud.githubusercontent.com/assets/313450/14318514/748db1d8-fc0d-11e5-9db0-d888aedc2b48.png)

