### PR TITLE
Fix utf8 read

### DIFF
--- a/estep/format.py
+++ b/estep/format.py
@@ -50,7 +50,7 @@ def object2jekyll(data, contentProperty):
     try:
         return "---\n{0}---\n{1}\n".format(metadata, content)
     except UnicodeEncodeError:
-        return unicode("---\n{0}---\n{1}\n").format(unicode(metadata), unicode(content)).encode('UTF-8')
+        return unicode("---\n{0}---\n{1}\n").format(metadata, content)
 
 
 def jekyllfile2object(filename, schemaType=None, contentProperty='description', uriPrefix='http://software.esciencecenter.nl'):

--- a/estep/format.py
+++ b/estep/format.py
@@ -46,7 +46,10 @@ def object2jekyll(data, contentProperty):
     metadata = yaml.safe_dump(d, default_flow_style=False)
 
     content = data[contentProperty]
-    return "---\n{0}---\n{1}\n".format(metadata, content)
+    try:
+        return "---\n{0}---\n{1}\n".format(metadata, content)
+    except UnicodeEncodeError:
+        return unicode("---\n{0}---\n{1}\n").format(unicode(metadata), unicode(content)).encode('UTF-8')
 
 
 def jekyllfile2object(filename, schemaType=None, contentProperty='description', uriPrefix='http://software.esciencecenter.nl'):

--- a/estep/format.py
+++ b/estep/format.py
@@ -15,6 +15,7 @@
 import datetime
 import os
 import json
+import codecs
 
 import yaml
 import frontmatter
@@ -56,7 +57,7 @@ def jekyllfile2object(filename, schemaType=None, contentProperty='description', 
     """
     Converts a Jekyll file to a python dict. The schema and @id properties are deduced from
     """
-    with open(filename) as f:
+    with codecs.open(filename, encoding='UTF-8') as f:
         obj = jekyll2object(f.read(), contentProperty)
 
     fullpath = os.path.abspath(filename)
@@ -128,12 +129,12 @@ def jekyll2json(filename, outputDir, contentProperty='description'):
     """
     Converts a Jekyll file to JSON and saves it in given output directory.
     """
-    with open(filename, 'r') as f:
+    with codecs.open(filename, encoding='utf-8') as f:
         dataString = f.read()
 
     obj = jekyll2object(dataString, contentProperty)
 
     last_id_part = obj['@id'].rindex('/') + 1
     fname = os.path.join(outputDir, obj['@id'][last_id_part:] + '.json')
-    with open(fname, 'w') as f:
+    with codecs.open(fname, encoding='utf-8', mode='w') as f:
         json.dump(obj, f)

--- a/estep/schema.py
+++ b/estep/schema.py
@@ -16,6 +16,7 @@ import datetime
 import json
 import os
 import logging
+import codecs
 
 import jsonschema
 import requests
@@ -84,7 +85,7 @@ def load_schemas(schema_uris, schemadir=None):
         else:
             LOGGER.debug('Loading schema %s from %s', schema_uri, schemadir)
             schema_fn = schema_uri.replace('http://software.esciencecenter.nl/schema', schemadir)
-            with open(schema_fn) as f:
+            with codecs.open(schema_fn, encoding='utf-8') as f:
                 store[schema_uri] = json.load(f)
     return store
 

--- a/estep/script.py
+++ b/estep/script.py
@@ -16,6 +16,7 @@ from __future__ import print_function
 import os
 import sys
 import logging
+import codecs
 
 from docopt import docopt
 import yaml
@@ -171,7 +172,7 @@ def generate_reciprocal():
         for url, document in faulty_docs.items():
             path = url_to_path(url)
             LOGGER.info("Writing fixed file %s", path)
-            with open(path, 'w') as f:
+            with codecs.open(path, encoding='utf-8', mode='w') as f:
                 f.write(object2jekyll(document, 'description'))
 
         LOGGER.warning('Fixed %d missing relationships in %d documents', nr_errors, len(faulty_docs))


### PR DESCRIPTION
Should now also read UTF-8 correctly, not the locale of the editor (see #87).